### PR TITLE
Solicit to keep the connection alive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ keywords    = ["apns", "apple", "push", "notification", "http2", "http/2"]
 repository  = "https://github.com/tkabit/apns2"
 
 [dependencies]
-hyper = "~0.7"
 rustc-serialize = "~0.3"
 time = "~0.1"
+openssl = "~0.7"
+
+[dependencies.solicit]
+git = "https://github.com/pimeys/solicit"
+default-features = true
+features = ["tls"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 #[macro_use]
-extern crate hyper;
+extern crate solicit;
 extern crate rustc_serialize;
 extern crate time;
+extern crate openssl;
 
 pub mod provider;
 pub mod notification;
@@ -10,7 +11,7 @@ pub mod device_token;
 pub mod response;
 
 pub use provider::Provider;
-pub use notification::Notification;
+pub use notification::{Notification, NotificationOptions};
 pub use payload::{APS, APSAlert, APSLocalizedAlert, Payload};
 pub use device_token::DeviceToken;
 pub use response::Response;

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,39 +1,48 @@
 use payload::*;
 use device_token::*;
 
-pub struct Notification {
+pub struct Notification<'a> {
     // The Remote Notification Payload.
     pub payload: Payload,
 
     // Specify the hexadecimal string of the device token for the target device.
     pub device_token: DeviceToken,
 
+    // The optional settings for the notification
+    pub options: NotificationOptions<'a>,
+}
+
+pub struct NotificationOptions<'a> {
     // A canonical UUID that identifies the notification.
-    pub apns_id: Option<String>,
+    pub apns_id: Option<&'a str>,
 
     // A UNIX epoch date expressed in seconds (UTC).
-    pub apns_expiration: Option<String>,
+    pub apns_expiration: Option<i64>,
 
     // The priority of the notification.
     pub apns_priority: Option<u32>,
 
-    // The length of the body content.
-    pub content_length: Option<u32>,
-
     // The topic of the remote notification, which is typically the bundle ID for your app.
-    pub apns_topic: Option<String>,
+    pub apns_topic: Option<&'a str>,
 }
 
-impl Notification {
-    pub fn new(payload: Payload, token: DeviceToken) -> Notification {
-        Notification {
-            payload: payload,
-            device_token: token,
+impl<'a> Default for NotificationOptions<'a> {
+    fn default() -> NotificationOptions<'a> {
+        NotificationOptions {
             apns_id: None,
             apns_expiration: None,
             apns_priority: None,
-            content_length: None,
             apns_topic: None,
+        }
+    }
+}
+
+impl<'a> Notification<'a> {
+    pub fn new(payload: Payload, token: DeviceToken, options: NotificationOptions) -> Notification {
+        Notification {
+            payload: payload,
+            device_token: token,
+            options: options,
         }
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,83 +1,195 @@
-use std::path::Path;
-use hyper::Client;
-use hyper::header::Headers;
-use hyper::http::h2::Http2Protocol;
-use hyper::net::{HttpsConnector, Openssl};
+use solicit::http::client::tls::TlsConnector;
+use solicit::client::{Client};
+use solicit::http::{Header, Response as HttpResponse};
 use notification::*;
 use response::*;
+use openssl::ssl::{SslContext, SslMethod, SSL_VERIFY_NONE};
+use openssl::x509::X509;
+use openssl::crypto::pkey::PKey;
+use time::{Tm, Timespec, at};
+use rustc_serialize::json::{Json, Object};
+use std::str;
+use std::time::{Instant, Duration};
+use std::fmt::Display;
+use std::result::Result;
+use std::thread;
+use std::fs::File;
+use std::io::Read;
 
-static DEVELOPMENT: &'static str = "https://api.development.push.apple.com";
-static PRODUCTION: &'static str = "https://api.push.apple.com";
-
-// Request headers
-header! { (APNSId, "apns-id") => [String] }
-header! { (APNSExpiration, "apns-expiration") => [String] }
-header! { (APNSPriority, "apns-priority") => [String] }
-header! { (APNSTopic, "apns-topic") => [String] }
-header! { (APNSContentLength, "content-length") => [String] }
+static DEVELOPMENT: &'static str = "api.development.push.apple.com";
+static PRODUCTION: &'static str = "api.push.apple.com";
 
 pub struct Provider {
     pub client: Client,
-    pub path: String,
+    request_timeout: Duration
 }
 
 impl Provider {
-    pub fn new(sandbox: bool, certificate_path: &str, private_key_path: &str) -> Provider {
-        let ssl = Openssl::with_cert_and_key(Path::new(certificate_path),
-                                             Path::new(private_key_path))
-                      .unwrap();
-        let ssl_connector = HttpsConnector::new(ssl);
-        let client = Client::with_protocol(Http2Protocol::with_connector(ssl_connector));
-        let path = if sandbox {
-            format!("{}{}", DEVELOPMENT, "/3/device/")
-        } else {
-            format!("{}{}", PRODUCTION, "/3/device/")
-        };
+    pub fn new(sandbox: bool, certificate: &str, private_key: &str) -> Provider {
+        Provider::from_reader(sandbox,
+                              &mut File::open(certificate).unwrap(),
+                              &mut File::open(private_key).unwrap())
+    }
+
+    pub fn from_reader<R: Read>(sandbox: bool, certificate: &mut R, private_key: &mut R) -> Provider {
+        let host    = if sandbox { DEVELOPMENT } else { PRODUCTION };
+        let mut ctx = SslContext::new(SslMethod::Sslv23).unwrap();
+
+        let x509 = X509::from_pem(certificate).unwrap();
+        let pkey = PKey::private_key_from_pem(private_key).unwrap();
+
+        ctx.set_cipher_list("DEFAULT").unwrap();
+        ctx.set_certificate(&x509).unwrap();
+        ctx.set_private_key(&pkey).unwrap();
+        ctx.set_verify(SSL_VERIFY_NONE, None);
+
+        let connector = TlsConnector::with_context(host, &ctx);
+        let client    = Client::with_connector(connector).unwrap();
 
         Provider {
             client: client,
-            path: path,
+            request_timeout: Duration::new(2, 0),
         }
     }
 
-    pub fn push(&self, notification: Notification) -> Response {
-        let url = format!("{}{}", self.path, notification.device_token);
-        let url_str: &str = url.as_str();
-        let pay = notification.payload.to_string();
-        let pay_str: &str = pay.as_str();
-        println!("{}", pay_str);
+    pub fn push(&self, notification: Notification) -> Result<Response, Response> {
+        if let Ok(http_response) = self.request(notification) {
+            let status        = Provider::fetch_status(http_response.status_code().ok());
+            let apns_id       = Provider::fetch_apns_id(http_response.headers);
+            let json          = str::from_utf8(&http_response.body).ok().and_then(|v| Json::from_str(v).ok());
+            let object        = json.as_ref().and_then(|v| v.as_object());
+            let reason        = Provider::fetch_reason(object);
+            let timestamp     = Provider::fetch_timestamp(object);
 
-        // Add Headers
-        let mut headers = Headers::new();
-        let content_length = notification.payload.len();
-        headers.set(APNSContentLength(format!("{}", content_length)));
-        if let Some(apns_id) = notification.apns_id {
-            headers.set(APNSId(apns_id));
+            if status == APNSStatus::Success {
+                Ok(Response {
+                    status: status,
+                    reason: reason,
+                    timestamp: timestamp,
+                    apns_id: apns_id,
+                })
+
+            } else {
+                Err(Response {
+                    status: status,
+                    reason: reason,
+                    timestamp: timestamp,
+                    apns_id: apns_id,
+                })
+            }
+        } else {
+            Err(Response {
+                status: APNSStatus::Timeout,
+                reason: None,
+                timestamp: None,
+                apns_id: None,
+            })
         }
-        if let Some(apns_expiration) = notification.apns_expiration {
-            headers.set(APNSExpiration(apns_expiration));
-        }
-        if let Some(apns_priority) = notification.apns_priority {
-            headers.set(APNSExpiration(format!("{}", apns_priority)));
-        }
-        if let Some(apns_topic) = notification.apns_topic {
-            headers.set(APNSExpiration(apns_topic));
+    }
+
+    fn request(&self, notification: Notification) -> Result<HttpResponse, APNSStatus> {
+        let path = format!("/3/device/{}", notification.device_token).into_bytes();
+        let body = notification.payload.to_string().into_bytes();
+
+        let mut headers = Vec::new();
+        headers.push(Provider::create_header("content_length", notification.payload.len()));
+
+        if let Some(apns_id) = notification.options.apns_id {
+            headers.push(Provider::create_header("apns-id", apns_id));
         }
 
-        // Send request to APNS server
-        let res = self.client
-                      .post(url_str)
-                      .body(pay_str)
-                      .headers(headers)
-                      .send()
-                      .unwrap();
-        println!("{:?}", res);
+        if let Some(apns_expiration) = notification.options.apns_expiration {
+            headers.push(Provider::create_header("apns-expiration", apns_expiration));
+        }
 
-        Response {
-            status: APNSStatus::Success,
-            reason: Some(APNSError::PayloadEmpty),
-            timestamp: None,
-            apns_id: None,
+        if let Some(apns_priority) = notification.options.apns_priority {
+            headers.push(Provider::create_header("apns-priority", apns_priority));
+        }
+
+        if let Some(apns_topic) = notification.options.apns_topic {
+            headers.push(Provider::create_header("apns-topic", apns_topic));
+        }
+
+        let resp = self.client.post(&path, headers.as_slice(), body).unwrap();
+        let now = Instant::now();
+
+        while now.elapsed() < self.request_timeout {
+            match resp.try_recv() {
+                Ok(http_response) => return Ok(http_response),
+                _                 => thread::park_timeout(Duration::from_millis(10)),
+            }
+        }
+
+        Err(APNSStatus::Timeout)
+    }
+
+    fn create_header<'a, T: Display>(key: &'a str, value: T) -> Header<'a, 'a> {
+        Header::new(key.as_bytes(), format!("{}", value).into_bytes())
+    }
+
+    fn fetch_status(code: Option<u16>) -> APNSStatus {
+        match code {
+            Some(200) => APNSStatus::Success,
+            Some(400) => APNSStatus::BadRequest,
+            Some(403) => APNSStatus::Forbidden,
+            Some(405) => APNSStatus::MethodNotAllowed,
+            Some(410) => APNSStatus::Unregistered,
+            Some(413) => APNSStatus::PayloadTooLarge,
+            Some(429) => APNSStatus::TooManyRequests,
+            Some(500) => APNSStatus::InternalServerError,
+            Some(503) => APNSStatus::ServiceUnavailable,
+            _         => APNSStatus::Unknown,
+        }
+    }
+
+    fn fetch_apns_id(headers: Vec<Header>) -> Option<String> {
+        headers.iter().find(|&header| {
+            match str::from_utf8(header.name()).unwrap() {
+                "apns-id" => true,
+                _         => false,
+            }
+        }).map(|header| {
+            String::from_utf8(header.value().to_vec()).unwrap()
+        })
+    }
+
+    fn fetch_reason(js_object: Option<&Object>) -> Option<APNSError> {
+        let raw_reason = js_object.and_then(|v| v.get("reason")).and_then(|v| v.as_string());
+
+        match raw_reason {
+            Some("PayloadEmpty")              => Some(APNSError::PayloadEmpty),
+            Some("PayloadTooLarge")           => Some(APNSError::PayloadTooLarge),
+            Some("BadTopic")                  => Some(APNSError::BadTopic),
+            Some("TopicDisallowed")           => Some(APNSError::TopicDisallowed),
+            Some("BadMessageId")              => Some(APNSError::BadMessageId),
+            Some("BadExpirationDate")         => Some(APNSError::BadExpirationDate),
+            Some("BadPriority")               => Some(APNSError::BadPriority),
+            Some("MissingDeviceToken")        => Some(APNSError::MissingDeviceToken),
+            Some("BadDeviceToken")            => Some(APNSError::BadDeviceToken),
+            Some("DeviceTokenNotForTopic")    => Some(APNSError::DeviceTokenNotForTopic),
+            Some("Unresgistered")             => Some(APNSError::Unregistered),
+            Some("DuplicateHeaders")          => Some(APNSError::DuplicateHeaders),
+            Some("BadCertificateEnvironment") => Some(APNSError::BadCertificateEnvironment),
+            Some("BadCertificate")            => Some(APNSError::BadCertificate),
+            Some("Forbidden")                 => Some(APNSError::Forbidden),
+            Some("BadPath")                   => Some(APNSError::BadPath),
+            Some("MethodNotAllowed")          => Some(APNSError::MethodNotAllowed),
+            Some("TooManyRequests")           => Some(APNSError::TooManyRequests),
+            Some("IdleTimeout")               => Some(APNSError::IdleTimeout),
+            Some("Shutdown")                  => Some(APNSError::Shutdown),
+            Some("InternalServerError")       => Some(APNSError::InternalServerError),
+            Some("ServiceUnavailable")        => Some(APNSError::ServiceUnavailable),
+            Some("MissingTopic")              => Some(APNSError::MissingTopic),
+            _                                 => None,
+        }
+    }
+
+    fn fetch_timestamp(js_object: Option<&Object>) -> Option<Tm> {
+        let raw_ts = js_object.and_then(|v| v.get("timestamp")).and_then(|v| v.as_i64());
+
+        match raw_ts {
+            Some(ts) => Some(at(Timespec::new(ts, 0))),
+            None     => None,
         }
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use time::Tm;
 
 use self::APNSError::*;
+
 // The APNS reasons.
 pub enum APNSError {
     PayloadEmpty,
@@ -35,6 +36,7 @@ impl fmt::Debug for APNSError {
         f.write_str(self.description())
     }
 }
+
 
 impl fmt::Display for APNSError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -92,6 +94,7 @@ impl Error for APNSError {
 }
 
 // The HTTP status code.
+#[derive(Debug, PartialEq)]
 pub enum APNSStatus {
     Success = 200, // Success
     BadRequest = 400, // Bad request
@@ -102,8 +105,11 @@ pub enum APNSStatus {
     TooManyRequests = 429, // The server received too many requests for the same device token.
     InternalServerError = 500, // Internal server error
     ServiceUnavailable = 503, // The server is shutting down and unavailable.
+    Timeout = 998,
+    Unknown = 999,
 }
 
+#[derive(Debug)]
 pub struct Response {
     // Status codes for a response
     pub status: APNSStatus,


### PR DESCRIPTION
Hi,

I've been doing a bit of testing to create a push notification service with Rust. I tried this library and got it working, only to notice that we open and close a connection for every single notification sent through the library.

This is a WIP idea to use the same connection for notifications, and I can see with scapy that we do one S/SA/A per process instead per notification. Apple has a tendency to block you if opening/closing too many connections, which would make the current state of the library unusable for high traffic production usage.

Why I used Solicit was that I couldn't get the current Hyper master working properly with async http2. It seems they've disabled the module for now. The Solicit library is also pretty old, although I was able to hack it to work (with a pretty ugly change, removing one check). https://github.com/pimeys/solicit/commit/3031127819477bee83b00a2a670ad81974018a96

Although this works nicely, but I'd like to get some feedback.
